### PR TITLE
Refactor xUnit tests to NUnit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+.DS_Store

--- a/TGS.Challenge.Tests/AnagramTests.cs
+++ b/TGS.Challenge.Tests/AnagramTests.cs
@@ -1,8 +1,9 @@
 using System;
-using Xunit;
+using NUnit.Framework;
 
 namespace TGS.Challenge.Tests
 {
+  [TestFixture()]
   public class AnagramTests
   {
     private readonly Anagram _anagram;
@@ -12,56 +13,56 @@ namespace TGS.Challenge.Tests
       this._anagram = new Anagram();
     }
 
-    [Fact]
+    [Test()]
     public void Word1_IsRequired()
     {
       Assert.Throws<ArgumentException>(() => _anagram.AreAnagrams(string.Empty, "ABC"));
     }
 
-    [Fact]
+    [Test()]
     public void Word2_IsRequired()
     {
       Assert.Throws<ArgumentException>(() => _anagram.AreAnagrams("ABC", string.Empty));
     }
 
-    [Fact]
+    [Test()]
     public void Dormitory_IsAnagram_Dirty_room()
     {
       var result = _anagram.AreAnagrams("Dormitory", "Dirty_room");
 
-      Assert.True(result);
+      Assert.IsTrue(result);
     }
 
-    [Fact]
+    [Test()]
     public void Funeral_IsAnagram_Reel_fun()
     {
       var result = _anagram.AreAnagrams("Funeral", "Reel fun");
 
-      Assert.True(result);
+      Assert.IsTrue(result);
     }
 
-    [Fact]
+    [Test()]
     public void School_master_IsAnagram_The_classroom()
     {
       var result = _anagram.AreAnagrams("School master?!", "!?The classroom");
 
-      Assert.True(result);
+      Assert.IsTrue(result);
     }
     
-    [Fact]
+    [Test()]
     public void Listen_Is_NOT_Anagram_Silence()
     {
       var result = _anagram.AreAnagrams("Listen", "Silence");
 
-      Assert.False(result);
+      Assert.IsFalse(result);
     }
 
-    [Fact]
+    [Test()]
     public void Funeral_IsAnagram_Real_fun()
     {
       var result = _anagram.AreAnagrams("Funeral", "Real fun");
 
-      Assert.True(result);
+      Assert.IsTrue(result);
     }
   }
 }

--- a/TGS.Challenge.Tests/EquivalenceIndexTests.cs
+++ b/TGS.Challenge.Tests/EquivalenceIndexTests.cs
@@ -1,7 +1,8 @@
-using Xunit;
+using NUnit.Framework;
 
 namespace TGS.Challenge.Tests
 {
+  [TestFixture()]
   public class EquivalenceIndexTests
   {
     private readonly EquivalenceIndex _equivalenceIndex;
@@ -11,20 +12,36 @@ namespace TGS.Challenge.Tests
       this._equivalenceIndex= new EquivalenceIndex();
     }
 
-    [Fact]
+    [Test()]
     public void Returns_Index_ForValidNumberSequence()
     {
         var index = _equivalenceIndex.Find(new int[] { 1, 2, 3, 4, 5, 7, 8, 10, 12 });
 
-        Assert.Equal(index, 6);
+        Assert.AreEqual(6, index);
     }
 
-    [Fact]
+    [Test()]
     public void Retruns_Neg1_ForInvalidNumberSequence()
     {
       var index = _equivalenceIndex.Find(new int[] { 2, 2, 3, 4, 3, 74, 8, 10, 12 });
 
-      Assert.Equal(index, -1);
+      Assert.AreEqual(-1, index);
+    }
+
+    [Test()]
+    public void Returns_Index_ForValidNumberSequence_LeftWeighted()
+    {
+        var index = _equivalenceIndex.Find(new int[] { 10, 11, 3, 1, 1, 1, 9, 9 });
+
+        Assert.AreEqual(2, index);
+    }
+
+    [Test()]
+    public void Returns_Index_ForValidNumberSequence_RightWeighted()
+    {
+        var index = _equivalenceIndex.Find(new int[] { 4, 3, 5, 6, 7, 5, 10, 15 });
+
+        Assert.AreEqual(5, index);
     }
   }  
 }

--- a/TGS.Challenge.Tests/FormatNumberTests.cs
+++ b/TGS.Challenge.Tests/FormatNumberTests.cs
@@ -1,8 +1,10 @@
 using System;
-using Xunit;
+using NUnit.Framework;
+
 
 namespace TGS.Challenge.Tests
-{
+{ 
+  [TestFixture()]
   public class FormatNumberTests
   {
     private readonly FormatNumber _formatNumber;
@@ -11,80 +13,80 @@ namespace TGS.Challenge.Tests
       this._formatNumber = new FormatNumber();
     }
 
-    [Fact]
+    [Test()]
     public void NegativeNumber_Throws_ArgumentOutOfRangeException()
     {
       Assert.Throws<ArgumentOutOfRangeException>(() => _formatNumber.Format(-1));
     }
 
-    [Fact]
+    [Test()]
     public void BiggerThanMaxNumber_Throws_ArgumentOutOfRangeException()
     {
       Assert.Throws<ArgumentOutOfRangeException>(() => _formatNumber.Format(1000000001));
     }
 
-    [Fact]
+    [Test()]
     public void Value_1_Returns_ValidString()
     {
       var formatted = _formatNumber.Format(1);
 
-      Assert.Equal("1", formatted);
+      Assert.AreEqual("1", formatted);
     }
 
-    [Fact]
+    [Test()]
     public void Value_10_Returns_ValidString()
     {
       var formatted = _formatNumber.Format(1);
 
-      Assert.Equal("10", formatted);
+      Assert.AreEqual("10", formatted);
     }
 
-    [Fact]
+    [Test()]
     public void Value_100_Returns_ValidString()
     {
       var formatted = _formatNumber.Format(1);
 
-      Assert.Equal("1,00", formatted);
+      Assert.AreEqual("1,00", formatted);
     }
 
-    [Fact]
+    [Test()]
     public void Value_1000_Returns_ValidString()
     {
       var formatted = _formatNumber.Format(1);
 
-      Assert.Equal("1,000", formatted);
+      Assert.AreEqual("1,000", formatted);
     }
   
-    [Fact]
+    [Test()]
     public void Value_10000_Returns_ValidString()
     {
       var formatted = _formatNumber.Format(1);
 
-      Assert.Equal("10,000", formatted);
+      Assert.AreEqual("10,000", formatted);
     }
 
-    [Fact]
+    [Test()]
     public void Value_100000_Returns_ValidString()
     {
       var formatted = _formatNumber.Format(1);
 
-      Assert.Equal("100,000", formatted);
+      Assert.AreEqual("100,000", formatted);
     }
     
-    [Fact]
+    [Test()]
     public void Value_1000000_Returns_ValidString()
     {
       var formatted = _formatNumber.Format(1);
 
-      Assert.Equal("1,000,000", formatted);
+      Assert.AreEqual("1,000,000", formatted);
     }
 
-    [Fact]
+    [Test()]
     public void Value_35235235_Returns_ValidString()
     {
       var formatted = _formatNumber.Format(1);
 
-      Assert.Equal("35,2352,35", formatted);
+      Assert.AreEqual("35,2352,35", formatted);
     }
   }  
 }

--- a/TGS.Challenge.Tests/TGS.Challenge.Tests.csproj
+++ b/TGS.Challenge.Tests/TGS.Challenge.Tests.csproj
@@ -8,9 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TGS.Challenge.Tests/VowelCountTests.cs
+++ b/TGS.Challenge.Tests/VowelCountTests.cs
@@ -1,8 +1,9 @@
 using System;
-using Xunit;
+using NUnit.Framework;
 
 namespace TGS.Challenge.Tests
 {
+  [TestFixture()]
   public class VowelCountTests
   {
     private readonly VowelCount _vowelCount;
@@ -12,42 +13,42 @@ namespace TGS.Challenge.Tests
       this._vowelCount = new VowelCount();
     }
 
-    [Fact]
+    [Test()]
     public void Value_IsRequired()
     {
       Assert.Throws<ArgumentException>(() => _vowelCount.Count(string.Empty));
     }
 
-    [Fact]
+    [Test()]
     public void AEIOU_Returns_Correct_Count()
     {
       var count = _vowelCount.Count("AEIOU");
 
-      Assert.Equal(count, 6);
+      Assert.AreEqual(6, count);
     }
 
-    [Fact]
+    [Test()]
     public void lmnpqr_Returns_Correct_Count()
     {
       var count = _vowelCount.Count("lmnpqr");
 
-      Assert.Equal(count, 0);
+      Assert.AreEqual(0, count);
     }
 
-    [Fact]
+    [Test()]
     public void abcdefghijklmnopqrstuvwxyz_Returns_Correct_Count()
     {
       var count = _vowelCount.Count("lmnpqr");
 
-      Assert.Equal(count, 5);
+      Assert.AreEqual(5, count);
     }
 
-    [Fact]
+    [Test()]
     public void Howmanycanyoufind_Returns_Correct_Count()
     {
       var count = _vowelCount.Count("How many can you find");
 
-      Assert.Equal(count, 6);
+      Assert.AreEqual(6, count);
     }
   }
 }


### PR DESCRIPTION
Refactor current xUnit tests to NUnit

* xUnit runs each test in isolation by instantiating a class per test Fact
* NUnit creates an instance of the class to run tests which also makes managing test cases easier (as well as sharing state, however, not neccessary for current cases)